### PR TITLE
assume default service port for probe, if no port is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Possible directives to use in a probe definition.
   amqp {
     host = {
       hostname = "localhost"
-      port = 3306
+      port = 5672
     }
     credentials = {
       user = "foo"
@@ -152,7 +152,7 @@ Possible directives to use in a probe definition.
   mongodb {
     host = {
       hostname = "localhost"
-      port = 3306
+      port = 27017
     }
     credentials = {
       user = "foo"
@@ -171,6 +171,8 @@ Possible directives to use in a probe definition.
     timeout = "5"
   }
 ```
+
+Specifying a `port` is optional and defaults to the services default port.
 
 ### HCL examples
 #### Start a process

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"os"
 	"strings"
+	log "github.com/sirupsen/logrus"
 )
 
 func ResolveEnv(in string) string {
@@ -10,4 +11,12 @@ func ResolveEnv(in string) string {
 		return os.Getenv(in[4:])
 	}
 	return in
+}
+
+func SetDefaultPort(port string, defaultPort string) string {
+	if len(port) == 0 {
+		log.Infof("No port specified or env variable not found, assuming default port %s", defaultPort)
+		return defaultPort
+	}
+	return port
 }

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -13,7 +13,7 @@ func ResolveEnv(in string) string {
 	return in
 }
 
-func SetDefaultPort(port string, defaultPort string) string {
+func SetDefaultStringIfEmpty(port string, defaultPort string) string {
 	if len(port) == 0 {
 		log.Infof("No port specified or env variable not found, assuming default port %s", defaultPort)
 		return defaultPort

--- a/pkg/probe/probe_amqp.go
+++ b/pkg/probe/probe_amqp.go
@@ -25,7 +25,7 @@ func NewAmqpProbe(cfg *config.Amqp) *amqpProbe {
 	cfg.User = helper.ResolveEnv(cfg.User)
 	cfg.Password = helper.ResolveEnv(cfg.Password)
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
-	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "5672")
+	cfg.Port = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Port), "5672")
 	cfg.VirtualHost = helper.ResolveEnv(cfg.VirtualHost)
 	if cfg.VirtualHost == "" {
 		cfg.VirtualHost = defaultVirtualHost

--- a/pkg/probe/probe_amqp.go
+++ b/pkg/probe/probe_amqp.go
@@ -25,7 +25,7 @@ func NewAmqpProbe(cfg *config.Amqp) *amqpProbe {
 	cfg.User = helper.ResolveEnv(cfg.User)
 	cfg.Password = helper.ResolveEnv(cfg.Password)
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
-	cfg.Port = helper.ResolveEnv(cfg.Port)
+	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "5672")
 	cfg.VirtualHost = helper.ResolveEnv(cfg.VirtualHost)
 	if cfg.VirtualHost == "" {
 		cfg.VirtualHost = defaultVirtualHost

--- a/pkg/probe/probe_http.go
+++ b/pkg/probe/probe_http.go
@@ -28,8 +28,8 @@ func NewHttpProbe(cfg *config.HttpGet) *httpGetProbe {
 		cfg.Scheme = "http"
 	}
 
-	host := cfg.Host.Hostname
-	if cfg.Host.Port != "" {
+	host := cfg.Hostname
+	if cfg.Port != "" {
 		host = fmt.Sprintf("%s:%s", cfg.Hostname, cfg.Port)
 	}
 

--- a/pkg/probe/probe_mongodb.go
+++ b/pkg/probe/probe_mongodb.go
@@ -26,6 +26,7 @@ func NewMongoDBProbe(cfg *config.MongoDB) *mongoDBProbe {
 	cfg.Password = helper.ResolveEnv(cfg.Password)
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
 	cfg.Database = helper.ResolveEnv(cfg.Database)
+	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "27017")
 
 	connCfg := mongoDBProbe{
 		user:     cfg.User,

--- a/pkg/probe/probe_mongodb.go
+++ b/pkg/probe/probe_mongodb.go
@@ -26,7 +26,7 @@ func NewMongoDBProbe(cfg *config.MongoDB) *mongoDBProbe {
 	cfg.Password = helper.ResolveEnv(cfg.Password)
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
 	cfg.Database = helper.ResolveEnv(cfg.Database)
-	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "27017")
+	cfg.Port = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Port), "27017")
 
 	connCfg := mongoDBProbe{
 		user:     cfg.User,

--- a/pkg/probe/probe_mysql.go
+++ b/pkg/probe/probe_mysql.go
@@ -18,7 +18,7 @@ func NewMySQLProbe(cfg *config.MySQL) *mySQLProbe {
 	cfg.Database = helper.ResolveEnv(cfg.Database)
 	cfg.Password = helper.ResolveEnv(cfg.Password)
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
-	cfg.Port = helper.ResolveEnv(cfg.Port)
+	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "3306")
 
 	connCfg := mysql.Config{
 		User:   cfg.User,

--- a/pkg/probe/probe_mysql.go
+++ b/pkg/probe/probe_mysql.go
@@ -18,7 +18,7 @@ func NewMySQLProbe(cfg *config.MySQL) *mySQLProbe {
 	cfg.Database = helper.ResolveEnv(cfg.Database)
 	cfg.Password = helper.ResolveEnv(cfg.Password)
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
-	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "3306")
+	cfg.Port = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Port), "3306")
 
 	connCfg := mysql.Config{
 		User:   cfg.User,

--- a/pkg/probe/probe_redis.go
+++ b/pkg/probe/probe_redis.go
@@ -16,7 +16,7 @@ type redisProbe struct {
 func NewRedisProbe(cfg *config.Redis) *redisProbe {
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
 	cfg.Password = helper.ResolveEnv(cfg.Password)
-	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "6379")
+	cfg.Port = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Port), "6379")
 
 	return &redisProbe{
 		addr:     fmt.Sprintf("%s:%s", cfg.Hostname, cfg.Port),

--- a/pkg/probe/probe_redis.go
+++ b/pkg/probe/probe_redis.go
@@ -16,7 +16,7 @@ type redisProbe struct {
 func NewRedisProbe(cfg *config.Redis) *redisProbe {
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
 	cfg.Password = helper.ResolveEnv(cfg.Password)
-	cfg.Port = helper.ResolveEnv(cfg.Port)
+	cfg.Port = helper.SetDefaultPort(helper.ResolveEnv(cfg.Port), "6379")
 
 	return &redisProbe{
 		addr:     fmt.Sprintf("%s:%s", cfg.Hostname, cfg.Port),


### PR DESCRIPTION
Use default ports on MySQL, AMQP, MongoDB and Redis service probes, if none are specified.