### PR TITLE
rename max_attempts to maxAttempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Possible directives to use in a job definition.
 job "foo" {
   command = "/usr/local/bin/foo"
   args = "bar"
-  max_attempts = 3
+  maxAttempts = 3
   canFail = false
   
   watch "/etc/conf.d/barfoo" {

--- a/internal/config/ignitionconfig.go
+++ b/internal/config/ignitionconfig.go
@@ -33,5 +33,12 @@ func (ignitionConfig *Ignition) GenerateFromConfigDir(configDir string) error {
 		}
 	}
 
+	for _, job := range ignitionConfig.Jobs {
+		if job.MaxAttempts_ != 0 {
+			log.Infof("field max_attempts in job %s is deprecated in favor of maxAttempts", job.Name)
+			job.MaxAttempts = job.MaxAttempts_
+		}
+	}
+
 	return nil
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -58,13 +58,14 @@ type Watch struct {
 }
 
 type JobConfig struct {
-	Name        string   `hcl:",key"`
-	Command     string   `hcl:"command"`
-	Args        []string `hcl:"args"`
-	Watches     []Watch  `hcl:"watch"`
-	MaxAttempts int      `hcl:"max_attempts"`
-	CanFail     bool     `hcl:"canFail"`
-	OneTime     bool     `hcl:"oneTime"`
+	Name         string   `hcl:",key"`
+	Command      string   `hcl:"command"`
+	Args         []string `hcl:"args"`
+	Watches      []Watch  `hcl:"watch"`
+	MaxAttempts_ int      `hcl:"max_attempts"` // deprecated
+	MaxAttempts  int      `hcl:"maxAttempts"`
+	CanFail      bool     `hcl:"canFail"`
+	OneTime      bool     `hcl:"oneTime"`
 }
 
 type File struct {


### PR DESCRIPTION
this change is backwards-compatible, a warning about the future
deprecation will be logged at every start of mittnite.

fixes #17 