### PR TITLE
Fix graceful shutdown of (lazy) jobs

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -80,7 +80,7 @@ var up = &cobra.Command{
 		runner := proc.NewRunner(ignitionConfig)
 		go func() {
 			<-procSignals
-			runner.Shutdown(nil)
+			cancel()
 		}()
 
 		if err := runner.Boot(ctx); err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -80,7 +80,7 @@ var up = &cobra.Command{
 		runner := proc.NewRunner(ignitionConfig)
 		go func() {
 			<-procSignals
-			cancel()
+			runner.Shutdown(nil)
 		}()
 
 		if err := runner.Boot(ctx); err != nil {

--- a/pkg/proc/job.go
+++ b/pkg/proc/job.go
@@ -120,6 +120,7 @@ func (job *Job) Stop() {
 	attempts := 0
 
 	// wait for the process to stop
+	// nolint:S1000
 	for {
 		select {
 		case <-timer.C:

--- a/pkg/proc/job.go
+++ b/pkg/proc/job.go
@@ -34,8 +34,6 @@ func (job *Job) Init() {
 }
 
 func (job *Job) Run(ctx context.Context, errors chan<- error) error {
-	ctx, job.cancelAll = context.WithCancel(ctx)
-
 	listerWaitGroup := sync.WaitGroup{}
 	defer listerWaitGroup.Wait()
 
@@ -44,6 +42,7 @@ func (job *Job) Run(ctx context.Context, errors chan<- error) error {
 		if err != nil {
 			return err
 		}
+		job.listeners = append(job.listeners, listener)
 
 		listerWaitGroup.Add(1)
 
@@ -95,9 +94,7 @@ func (job *Job) startProcessReaper(ctx context.Context) {
 
 				job.lazyStartLock.Lock()
 
-				if job.cancelProcess != nil {
-					job.cancelProcess()
-				}
+				job.Signal(syscall.SIGTERM)
 
 				job.lazyStartLock.Unlock()
 			}
@@ -105,15 +102,48 @@ func (job *Job) startProcessReaper(ctx context.Context) {
 	}()
 }
 
+func (job *Job) Stop() {
+	job.cancel = true
+
+	// First closing all listeners to prevent new job starts
+	for _, listener := range job.listeners {
+		listener.Shutdown()
+	}
+
+	if !job.running {
+		return
+	}
+
+	// send SIGTERM to the process for a graceful shutdown
+	job.Signal(syscall.SIGTERM)
+	timer := time.NewTicker(1 * time.Second)
+	attempts := 0
+
+	// wait for the process to stop
+	for {
+		select {
+		case <-timer.C:
+			if !job.running {
+				return
+			}
+
+			// kill the process after the max wait time
+			if attempts >= SchutdownWaitingTimeSeconds {
+				if job.kill != nil {
+					job.kill()
+				}
+				return
+			}
+			attempts++
+		}
+	}
+}
+
 func (job *Job) Signal(sig os.Signal) {
 	errFunc := func(err error) {
 		if err != nil {
 			log.Warnf("failed to send signal %d to job %s: %s", sig, job.Config.Name, err.Error())
 		}
-	}
-
-	if sig == syscall.SIGTERM && job.cancelAll != nil {
-		job.cancelAll()
 	}
 
 	if job.cmd == nil || job.cmd.Process == nil {

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -60,9 +62,7 @@ func (job *Job) start(ctx context.Context, process chan<- *os.Process) error {
 		maxAttempts = 3
 	}
 
-	ctx, job.kill = context.WithCancel(ctx)
-
-	job.cmd = exec.CommandContext(ctx, job.Config.Command, job.Config.Args...)
+	job.cmd = exec.Command(job.Config.Command, job.Config.Args...)
 	job.cmd.Stdout = os.Stdout
 	job.cmd.Stderr = os.Stderr
 	if job.Config.Env != nil {
@@ -70,10 +70,6 @@ func (job *Job) start(ctx context.Context, process chan<- *os.Process) error {
 	}
 
 	for { // restart failed jobs as long mittnite is running
-		if job.cancel {
-			return nil
-		}
-
 		l.Info("starting job")
 
 		err := job.cmd.Start()
@@ -81,38 +77,57 @@ func (job *Job) start(ctx context.Context, process chan<- *os.Process) error {
 			return fmt.Errorf("failed to start job %s: %s", job.Config.Name, err.Error())
 		}
 
-		job.running = true
 		if process != nil {
 			process <- job.cmd.Process
 		}
 
-		err = job.cmd.Wait()
-		job.running = false
-		if err != nil {
-			l.WithError(err).Error("job exited with error")
-		} else {
-			if job.Config.OneTime {
-				l.Info("one-time job has ended successfully")
+		errChan := make(chan error, 1)
+		go func() {
+			errChan <- job.cmd.Wait()
+		}()
+
+		select {
+		// job errChan or failed
+		case err := <-errChan:
+			if err != nil {
+				l.WithError(err).Error("job exited with error")
+			} else {
+				if job.Config.OneTime {
+					l.Info("one-time job has ended successfully")
+					return nil
+				}
+				l.Warn("job exited without errors")
+			}
+
+			attempts++
+			if attempts < maxAttempts {
+				l.WithField("job.maxAttempts", maxAttempts).WithField("job.usedAttempts", attempts).Info("remaining attempts")
+				continue
+			}
+
+			if job.Config.CanFail {
+				l.WithField("job.maxAttempts", maxAttempts).Warn("reached max retries")
 				return nil
 			}
-			l.Warn("job exited without errors")
-		}
 
-		if ctx.Err() != nil { // execution cancelled
-			return nil
-		}
+			close(errChan)
+			return fmt.Errorf("reached max retries for job %s", job.Config.Name)
+		case <-ctx.Done():
+			// ctx canceled, try to terminate job
+			_ = job.cmd.Process.Signal(syscall.SIGTERM)
 
-		attempts++
-		if attempts < maxAttempts {
-			l.WithField("job.maxAttempts", maxAttempts).WithField("job.usedAttempts", attempts).Info("remaining attempts")
-			continue
-		}
+			select {
+			case <-time.After(time.Second * ShutdownWaitingTimeSeconds):
+				// process seems to hang, kill process
+				_ = job.cmd.Process.Kill()
+				l.WithField("job.name", job.Config.Name).Warn("forcefully killed job")
+				return nil
 
-		if job.Config.CanFail {
-			l.WithField("job.maxAttempts", maxAttempts).Warn("reached max retries")
-			return nil
+			case err := <-errChan:
+				// all good
+				close(errChan)
+				return err
+			}
 		}
-
-		return fmt.Errorf("reached max retries for job %s", job.Config.Name)
 	}
 }

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -120,7 +120,7 @@ func (job *Job) start(ctx context.Context, process chan<- *os.Process) error {
 			case <-time.After(time.Second * ShutdownWaitingTimeSeconds):
 				// process seems to hang, kill process
 				_ = job.cmd.Process.Kill()
-				l.WithField("job.name", job.Config.Name).Warn("forcefully killed job")
+				l.WithField("job.name", job.Config.Name).Error("forcefully killed job")
 				return nil
 
 			case err := <-errChan:

--- a/pkg/proc/job_listener.go
+++ b/pkg/proc/job_listener.go
@@ -87,8 +87,6 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 
 	go func() {
 		for {
-			// START DOM
-			// DAS IST DOCH ALLES KACKE ICH MACH MITTAG :D
 			var conn net.Conn
 			connChan := make(chan acceptResult, 1)
 			go func() {
@@ -113,7 +111,6 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 				}
 				conn = ar.conn
 			}
-			// END DOM
 
 			log.WithField("client.addr", conn.RemoteAddr()).Info("accepted connection")
 

--- a/pkg/proc/job_listener.go
+++ b/pkg/proc/job_listener.go
@@ -108,6 +108,7 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 			case ar := <-connChan:
 				if ar.err != nil {
 					errChan <- ar.err
+					return
 				}
 				conn = ar.conn
 			}

--- a/pkg/proc/runner.go
+++ b/pkg/proc/runner.go
@@ -67,7 +67,7 @@ func (r *Runner) Boot(ctx context.Context) error {
 		return ctx.Err()
 
 	case err := <-bootErrs:
-		log.Error("boot job error occurred", err)
+		log.Error("boot job error occurred: ", err)
 		return err
 	}
 }

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -1,7 +1,6 @@
 package proc
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"sync"
@@ -11,23 +10,20 @@ import (
 )
 
 const (
-	SchutdownWaitingTimeSeconds = 10
-	RunnerShuwtdownCause        = "job return error, shutting down other services"
+	ShutdownWaitingTimeSeconds = 10
 )
 
 type Runner struct {
 	IgnitionConfig *config.Ignition
 	jobs           []*Job
 	bootJobs       []*BootJob
-	shutdownChan   chan error
 }
 
 type BootJob struct {
-	Config        *config.BootJobConfig
-	cmd           *exec.Cmd
-	process       *os.Process
-	timeout       time.Duration
-	cancelProcess context.CancelFunc
+	Config  *config.BootJobConfig
+	cmd     *exec.Cmd
+	process *os.Process
+	timeout time.Duration
 }
 
 type Job struct {
@@ -35,10 +31,6 @@ type Job struct {
 	watchingFiles map[string]time.Time
 	cmd           *exec.Cmd
 	process       *os.Process
-	cancel        bool
-	running       bool
-	kill          context.CancelFunc
-	listeners     []*Listener
 
 	lazyStartLock sync.Mutex
 

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -10,10 +10,16 @@ import (
 	"github.com/mittwald/mittnite/internal/config"
 )
 
+const (
+	SchutdownWaitingTimeSeconds = 10
+	RunnerShuwtdownCause        = "job return error, shutting down other services"
+)
+
 type Runner struct {
 	IgnitionConfig *config.Ignition
 	jobs           []*Job
 	bootJobs       []*BootJob
+	shutdownChan   chan error
 }
 
 type BootJob struct {
@@ -29,8 +35,10 @@ type Job struct {
 	watchingFiles map[string]time.Time
 	cmd           *exec.Cmd
 	process       *os.Process
-	cancelAll     context.CancelFunc
-	cancelProcess context.CancelFunc
+	cancel        bool
+	running       bool
+	kill          context.CancelFunc
+	listeners     []*Listener
 
 	lazyStartLock sync.Mutex
 


### PR DESCRIPTION
- Refactored context-handling for runner and jobs
- Shutdown jobs by sending SIGTERM instead of closing its context
- If graceful shutdown does not work, the context is closed anyway