### PR TITLE
use non blocking channel write for startOnce err

### DIFF
--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -2,7 +2,6 @@ package proc
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"sync"
 	"syscall"


### PR DESCRIPTION
startOnce will most likely exit once the wrapping method has already
returned, having written to job.process in the select statement.

This results in the err channel being left without readers, therefore
the go func will never exit if startOnce throws an error, as it can't write to e.