### PR TITLE
add support for probing plaintext SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ probe "probe-name" {
     password = ""
   }
   
+  smtp {
+    host = {
+      hostname = "localhost"
+      port = 25
+    }
+  }
+
   mysql {
     host = {
       hostname = "localhost"

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -39,6 +39,10 @@ type Redis struct {
 	Password string
 }
 
+type SMTP struct {
+	Host
+}
+
 type HttpGet struct {
 	Scheme string
 	Host
@@ -55,6 +59,7 @@ type Probe struct {
 	MongoDB    *MongoDB
 	Amqp       *Amqp
 	HTTP       *HttpGet
+	SMTP       *SMTP
 }
 
 type Watch struct {

--- a/pkg/probe/probe_smtp.go
+++ b/pkg/probe/probe_smtp.go
@@ -1,0 +1,43 @@
+package probe
+
+import (
+	"net"
+	"net/smtp"
+
+	"github.com/mittwald/mittnite/internal/config"
+	"github.com/mittwald/mittnite/internal/helper"
+	log "github.com/sirupsen/logrus"
+)
+
+type smtpProbe struct {
+	addr string
+}
+
+func NewSmtpProbe(cfg *config.SMTP) *smtpProbe {
+	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
+	cfg.Port = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Port), "25", "port", "smtp")
+
+	return &smtpProbe{
+		addr: net.JoinHostPort(cfg.Hostname, cfg.Port),
+	}
+}
+
+func (s *smtpProbe) Exec() error {
+	client, err := smtp.Dial(s.addr)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if err := client.Noop(); err != nil {
+		return err
+	}
+
+	if err := client.Quit(); err != nil {
+		return err
+	}
+
+	log.WithFields(log.Fields{"kind": "probe", "name": "smtp", "status": "alive", "host": s.addr}).Debug()
+
+	return nil
+}

--- a/pkg/probe/server.go
+++ b/pkg/probe/server.go
@@ -164,6 +164,8 @@ func buildProbesFromConfig(cfg *config.Ignition) (map[string]Probe, error) {
 			result[cfg.Probes[i].Name] = NewAmqpProbe(cfg.Probes[i].Amqp)
 		} else if cfg.Probes[i].HTTP != nil {
 			result[cfg.Probes[i].Name] = NewHttpProbe(cfg.Probes[i].HTTP)
+		} else if cfg.Probes[i].SMTP != nil {
+			result[cfg.Probes[i].Name] = NewSmtpProbe(cfg.Probes[i].SMTP)
 		}
 	}
 


### PR DESCRIPTION
a new SMTP-based connection probe using golang internal library functions. the probe connects to the server, issues a *NOOP* command and disconnects again.