### PR TITLE
HTTP probe: add support for HTTP methods, request payload and status …

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ probe "mongodb" {
 probe "http" {
   wait = true
   http {
+    method = "post"
     scheme = "http"
     host = {
         hostname = "localhost"
@@ -349,6 +350,13 @@ probe "http" {
     }
     path = "/status"
     timeout = "5s"
+    payload = "{\"body\": 123}"
+    # regex to match against the response status line
+    # (e.g. 403 Forbidden)
+    expectStatus = "(200|201)"
+    headers = {
+      Content-Type = "application/json"
+    }
   }
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -43,11 +43,15 @@ type SMTP struct {
 	Host
 }
 
-type HttpGet struct {
+type HTTP struct {
+	Method string
 	Scheme string
 	Host
-	Path    string
-	Timeout string
+	Path         string
+	Timeout      string
+	Payload      string
+	ExpectStatus string
+	Headers      map[string]string
 }
 
 type Probe struct {
@@ -58,7 +62,7 @@ type Probe struct {
 	Redis      *Redis
 	MongoDB    *MongoDB
 	Amqp       *Amqp
-	HTTP       *HttpGet
+	HTTP       *HTTP
 	SMTP       *SMTP
 }
 

--- a/pkg/probe/probe_http.go
+++ b/pkg/probe/probe_http.go
@@ -2,8 +2,11 @@ package probe
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/mittwald/mittnite/internal/config"
@@ -11,69 +14,86 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type httpGetProbe struct {
+type httpProbe struct {
+	method  string
 	scheme  string
 	host    string
 	path    string
-	timeout string
+	payload string
+	headers map[string]string
+	timeout time.Duration
+	status  *regexp.Regexp
 }
 
-func NewHttpProbe(cfg *config.HttpGet) *httpGetProbe {
-	cfg.Scheme = helper.ResolveEnv(cfg.Scheme)
+func NewHttpProbe(cfg *config.HTTP) (*httpProbe, error) {
+	cfg.Method = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Method), "GET", "method", "http")
+	cfg.Scheme = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Scheme), "http", "scheme", "http")
 	cfg.Hostname = helper.ResolveEnv(cfg.Hostname)
 	cfg.Port = helper.ResolveEnv(cfg.Port)
 	cfg.Path = helper.ResolveEnv(cfg.Path)
-	cfg.Timeout = helper.ResolveEnv(cfg.Timeout)
+	cfg.Timeout = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.Timeout), "5s", "timeout", "http")
+	cfg.ExpectStatus = helper.SetDefaultStringIfEmpty(helper.ResolveEnv(cfg.ExpectStatus), `(1|2|3)\d\d\s`, "expectStatus", "http")
 
-	if cfg.Scheme == "" {
-		cfg.Scheme = "http"
-	}
-
+	method := strings.ToUpper(cfg.Method)
 	host := cfg.Hostname
 	if cfg.Port != "" {
-		host = fmt.Sprintf("%s:%s", cfg.Hostname, cfg.Port)
+		host = net.JoinHostPort(cfg.Hostname, cfg.Port)
 	}
 
-	connCfg := httpGetProbe{
+	status, err := regexp.Compile(cfg.ExpectStatus)
+	if err != nil {
+		return nil, fmt.Errorf("invalid HTTP status line regexp: %w", err)
+	}
+
+	timeout, err := time.ParseDuration(cfg.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timeout duration: %w", err)
+	}
+
+	connCfg := &httpProbe{
+		method:  method,
 		scheme:  cfg.Scheme,
 		host:    host,
 		path:    cfg.Path,
-		timeout: cfg.Timeout,
+		status:  status,
+		timeout: timeout,
+		payload: cfg.Payload,
+		headers: cfg.Headers,
 	}
 
-	return &connCfg
+	return connCfg, nil
 }
 
-func (h *httpGetProbe) Exec() error {
-	timeout := time.Second * 5
-	if h.timeout != "" {
-		duration, err := time.ParseDuration(h.timeout)
-		if err == nil {
-			timeout = duration
-		} else {
-			return fmt.Errorf("invalid timeout duration: %s", err)
-		}
-	}
-
+func (h *httpProbe) Exec() error {
 	u := url.URL{
 		Scheme: h.scheme,
 		Host:   h.host,
 		Path:   h.path,
 	}
 	urlStr := u.String()
-
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout: h.timeout,
 	}
-	res, err := client.Get(urlStr)
+
+	data := strings.NewReader(h.payload)
+	req, err := http.NewRequest(h.method, u.String(), data)
 	if err != nil {
 		return err
 	}
 
-	if res.StatusCode >= 200 && res.StatusCode < 400 {
-		log.WithFields(log.Fields{"kind": "probe", "name": "http", "status": "alive", "host": urlStr}).Debug()
-		return nil
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
 	}
 
-	return fmt.Errorf("http service '%s' returned status code %d", urlStr, res.StatusCode)
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if !h.status.MatchString(res.Status) {
+		return fmt.Errorf("http service %q returned status %q", urlStr, res.Status)
+	}
+
+	log.WithFields(log.Fields{"kind": "probe", "name": "http", "status": "alive", "host": urlStr}).Debug()
+	return nil
 }


### PR DESCRIPTION
…validation

this extends the HTTP probe with additional properties related to the outgoing HTTP request. additionally a response status validation can be configured which is matched against the status line.

also the initialization has been refactored to error out on invalid duration definitions instead of failing the probe execution.