### PR TITLE
lazy: close upstream conn as well

### DIFF
--- a/pkg/proc/job_listener.go
+++ b/pkg/proc/job_listener.go
@@ -135,6 +135,7 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 					log.WithError(err).Error("error while dialling upstream")
 					return
 				}
+				defer upstream.Close()
 
 				toUpstreamErrors := make(chan error)
 				fromUpstreamErrors := make(chan error)
@@ -156,7 +157,6 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 				select {
 				case <-toUpstreamErrors:
 				case <-fromUpstreamErrors:
-					return
 				}
 			}()
 		}


### PR DESCRIPTION
mittnite has never closed an upstream connection after the client connection has been closed.