### PR TITLE
don't use parseFiles on existing template

### DIFF
--- a/pkg/files/render.go
+++ b/pkg/files/render.go
@@ -61,11 +61,12 @@ func renderFile(cfg *config.File) error {
 
 	log.Infof("creating configuration file %s from template %s", cfg.Target, cfg.Template)
 
-	tpl, err := newTemplate(cfg.Target).ParseFiles(cfg.Template)
+	tplContents, err := os.ReadFile(cfg.Template)
 	if err != nil {
 		return err
 	}
 
+	tpl, err := template.New(cfg.Target).Parse(string(tplContents))
 	folderPath, err := filepath.Abs(filepath.Dir(cfg.Target))
 	if err != nil {
 		return err


### PR DESCRIPTION
the old code would create a new empty template. ParseFiles would then do the same, and discard the parsed template if the original template is already initialized.