### PR TITLE
Fix deadlock on listener job + fix race

### DIFF
--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -108,7 +108,7 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 	defer job.closeStdFiles()
 
 	if err := job.CreateAndOpenStdFile(job.Config); err != nil {
-		return nil
+		return err
 	}
 
 	cmd := exec.Command(job.Config.Command, job.Config.Args...)

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -42,6 +42,8 @@ func (job *LazyJob) AssertStarted(ctx context.Context) error {
 
 		l.Info("process terminated")
 
+		job.lazyStartLock.Lock()
+		defer job.lazyStartLock.Unlock()
 		job.process = nil
 	}()
 


### PR DESCRIPTION
`startOnce()` msut return an error or write a process into the process channel