### PR TITLE
Treat lazy cool-down stops as expected instead of errors

### DIFF
--- a/pkg/proc/api.go
+++ b/pkg/proc/api.go
@@ -33,7 +33,7 @@ func (api *Api) Start() error {
 		Handler: api.router,
 	}
 
-	log.Infof("remote api listens on %s", api.srv.Addr)
+	log.WithField("api.addr", api.srv.Addr).Info("remote api listening")
 	if err := api.listen(); err != nil && err != http.ErrServerClosed {
 		return err
 	}

--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -21,8 +21,9 @@ import (
 var (
 	_ Job = &CommonJob{}
 
-	ProcessWillBeRestartedError = errors.New("process will be restarted")
-	ProcessWillBeStoppedError   = errors.New("process will be stopped")
+	ProcessWillBeRestartedError      = errors.New("process will be restarted")
+	ProcessWillBeStoppedError        = errors.New("process will be stopped")
+	ProcessStoppedIntentionallyError = errors.New("process stopped intentionally")
 )
 
 func (job *baseJob) SignalAll(sig syscall.Signal) {
@@ -106,6 +107,7 @@ func (job *baseJob) StreamStdOutAndStdErr(ctx context.Context, outChan chan []by
 
 func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) error {
 	l := log.WithField("job.name", job.Config.Name)
+	job.stopExpected = false
 	defer job.closeStdFiles()
 
 	if err := job.CreateAndOpenStdFile(job.Config); err != nil {
@@ -193,6 +195,11 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 		}
 
 		if err != nil {
+			if job.stopExpected && terminatedBySignal(err, syscall.SIGTERM) {
+				job.stopExpected = false
+				l.Info("process stopped as requested")
+				return ProcessStoppedIntentionallyError
+			}
 			l.WithError(err).Error("job exited with error")
 		}
 		return err

--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -27,41 +27,31 @@ var (
 )
 
 func (job *baseJob) SignalAll(sig syscall.Signal) {
-	errFunc := func(err error) {
-		if err != nil {
-			log.Warnf("failed to send signal %d to job %s: %s", sig, job.Config.Name, err.Error())
-		}
-	}
+	l := log.WithField("job.name", job.Config.Name).WithField("signal", sig)
 
 	if job.cmd == nil || job.cmd.Process == nil {
-		errFunc(
-			fmt.Errorf("job is not running"),
-		)
+		l.Warn("failed to send signal to process group: job is not running")
 		return
 	}
 
-	log.WithField("job.name", job.Config.Name).Infof("sending signal %d to process group", sig)
-	errFunc(syscall.Kill(-job.cmd.Process.Pid, sig))
+	l.Info("sending signal to process group")
+	if err := syscall.Kill(-job.cmd.Process.Pid, sig); err != nil {
+		l.WithError(err).Warn("failed to send signal to process group")
+	}
 }
 
 func (job *baseJob) Signal(sig os.Signal) {
-	errFunc := func(err error) {
-		if err != nil {
-			log.Warnf("failed to send signal %d to job %s: %s", sig, job.Config.Name, err.Error())
-		}
-	}
+	l := log.WithField("job.name", job.Config.Name).WithField("signal", sig)
 
 	if job.cmd == nil || job.cmd.Process == nil {
-		errFunc(
-			fmt.Errorf("job is not running"),
-		)
+		l.Warn("failed to send signal to process: job is not running")
 		return
 	}
 
-	log.WithField("job.name", job.Config.Name).Infof("sending signal %d to process", sig)
-	errFunc(
-		job.cmd.Process.Signal(sig),
-	)
+	l.Info("sending signal to process")
+	if err := job.cmd.Process.Signal(sig); err != nil {
+		l.WithError(err).Warn("failed to send signal to process")
+	}
 }
 
 func (job *baseJob) Reset() {
@@ -133,8 +123,9 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 		}
 		defer stderrPipe.Close()
 
-		go job.logWithTimestamp(stdoutPipe, job.stdout)
-		go job.logWithTimestamp(stderrPipe, job.stderr)
+		layout := job.resolveTimestampLayout(l)
+		go job.logWithTimestamp(stdoutPipe, job.stdout, layout)
+		go job.logWithTimestamp(stderrPipe, job.stderr, layout)
 	} else {
 		cmd.Stdout = job.stdout
 		cmd.Stderr = job.stderr
@@ -206,13 +197,13 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 	case <-ctx.Done():
 		// ctx canceled, try to terminate job
 		_ = syscall.Kill(-job.cmd.Process.Pid, syscall.SIGTERM)
-		l.WithField("job.name", job.Config.Name).Info("sent SIGTERM to job's process group")
+		l.Info("sent SIGTERM to job's process group")
 
 		select {
 		case <-time.After(time.Second * ShutdownWaitingTimeSeconds):
 			// process seems to hang, kill process
 			_ = syscall.Kill(-job.cmd.Process.Pid, syscall.SIGKILL)
-			l.WithField("job.name", job.Config.Name).Error("forcefully killed job")
+			l.Error("forcefully killed job")
 			return nil
 
 		case err := <-errChan:
@@ -234,25 +225,29 @@ func (job *baseJob) closeStdFiles() {
 	}
 }
 
-func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer) {
-	l := log.WithField("job.name", job.Config.Name)
-
-	var layout string
-
-	// has custom timestamp layout?
+// resolveTimestampLayout determines the timestamp layout for the job's log
+// output and logs the choice once per process start.
+func (job *baseJob) resolveTimestampLayout(l *log.Entry) string {
 	if job.Config.CustomTimestampFormat != "" {
-		layout = job.Config.CustomTimestampFormat
-		l.Infof("using custom timestamp layout '%s'", layout)
-	} else {
-		existingLayout, exists := TimeLayouts[job.Config.TimestampFormat]
-		if !exists {
-			layout = time.RFC3339
-			l.Warningf("unknown timestamp layout '%s', defaulting to RFC3339", job.Config.TimestampFormat)
-		} else {
-			layout = existingLayout
-			l.Infof("logging with timestamp layout '%s'", job.Config.TimestampFormat)
-		}
+		l.WithField("timestamp.layout", job.Config.CustomTimestampFormat).
+			Info("logging with custom timestamp layout")
+		return job.Config.CustomTimestampFormat
 	}
+
+	layout, exists := TimeLayouts[job.Config.TimestampFormat]
+	if !exists {
+		l.WithField("timestamp.layout", job.Config.TimestampFormat).
+			Warn("unknown timestamp layout, defaulting to RFC3339")
+		return time.RFC3339
+	}
+
+	l.WithField("timestamp.layout", job.Config.TimestampFormat).
+		Info("logging with timestamp layout")
+	return layout
+}
+
+func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer, layout string) {
+	l := log.WithField("job.name", job.Config.Name)
 
 	scanner := bufio.NewScanner(r)
 	prefix := []byte{'['}
@@ -276,13 +271,13 @@ func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer) {
 		lineBuffer.Write(newline)
 
 		if _, err := w.Write(lineBuffer.Bytes()); err != nil {
-			l.Errorf("error writing log line for process: %v\n", err)
+			l.WithError(err).Error("error writing log line for process")
 			continue
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		l.Errorf("error reading from process: %v\n", err)
+		l.WithError(err).Error("error reading from process")
 	}
 }
 

--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -107,7 +107,7 @@ func (job *baseJob) StreamStdOutAndStdErr(ctx context.Context, outChan chan []by
 
 func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) error {
 	l := log.WithField("job.name", job.Config.Name)
-	job.stopExpected = false
+	job.stopExpected.Store(false)
 	defer job.closeStdFiles()
 
 	if err := job.CreateAndOpenStdFile(job.Config); err != nil {
@@ -195,8 +195,8 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 		}
 
 		if err != nil {
-			if job.stopExpected && terminatedBySignal(err, syscall.SIGTERM) {
-				job.stopExpected = false
+			if job.stopExpected.Load() && terminatedBySignal(err, syscall.SIGTERM) {
+				job.stopExpected.Store(false)
 				l.Info("process stopped as requested")
 				return ProcessStoppedIntentionallyError
 			}

--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -226,7 +226,8 @@ func (job *baseJob) closeStdFiles() {
 }
 
 // resolveTimestampLayout determines the timestamp layout for the job's log
-// output and logs the choice once per process start.
+// output and logs the choice once per process start. timestamp.layout always
+// carries the effective Go time layout; timestamp.format the configured key.
 func (job *baseJob) resolveTimestampLayout(l *log.Entry) string {
 	if job.Config.CustomTimestampFormat != "" {
 		l.WithField("timestamp.layout", job.Config.CustomTimestampFormat).
@@ -236,12 +237,14 @@ func (job *baseJob) resolveTimestampLayout(l *log.Entry) string {
 
 	layout, exists := TimeLayouts[job.Config.TimestampFormat]
 	if !exists {
-		l.WithField("timestamp.layout", job.Config.TimestampFormat).
-			Warn("unknown timestamp layout, defaulting to RFC3339")
+		l.WithField("timestamp.format", job.Config.TimestampFormat).
+			WithField("timestamp.layout", time.RFC3339).
+			Warn("unknown timestamp format, defaulting to RFC3339")
 		return time.RFC3339
 	}
 
-	l.WithField("timestamp.layout", job.Config.TimestampFormat).
+	l.WithField("timestamp.format", job.Config.TimestampFormat).
+		WithField("timestamp.layout", layout).
 		Info("logging with timestamp layout")
 	return layout
 }

--- a/pkg/proc/basejob_test.go
+++ b/pkg/proc/basejob_test.go
@@ -1,0 +1,62 @@
+package proc
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/mittwald/mittnite/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func startTestJob(t *testing.T) (*baseJob, chan error) {
+	t.Helper()
+
+	job, err := newBaseJob(&config.BaseJobConfig{
+		Name:    "test-job",
+		Command: "sleep",
+		Args:    []string{"30"},
+	})
+	require.NoError(t, err)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- job.startOnce(context.Background(), nil)
+	}()
+
+	require.Eventually(t, func() bool {
+		return job.cmd != nil && job.cmd.Process != nil && syscall.Kill(job.cmd.Process.Pid, 0) == nil
+	}, 5*time.Second, 20*time.Millisecond, "process should be running")
+
+	return job, errChan
+}
+
+func TestStartOnceReportsExpectedStopAsIntentional(t *testing.T) {
+	job, errChan := startTestJob(t)
+
+	job.stopExpected = true
+	job.Signal(syscall.SIGTERM)
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, ProcessStoppedIntentionallyError)
+	case <-time.After(5 * time.Second):
+		t.Fatal("startOnce did not return")
+	}
+}
+
+func TestStartOnceReportsUnexpectedSignalAsError(t *testing.T) {
+	job, errChan := startTestJob(t)
+
+	job.Signal(syscall.SIGTERM)
+
+	select {
+	case err := <-errChan:
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ProcessStoppedIntentionallyError)
+		require.EqualError(t, err, "signal: terminated")
+	case <-time.After(5 * time.Second):
+		t.Fatal("startOnce did not return")
+	}
+}

--- a/pkg/proc/basejob_test.go
+++ b/pkg/proc/basejob_test.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"context"
+	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -20,14 +21,20 @@ func startTestJob(t *testing.T) (*baseJob, chan error) {
 	})
 	require.NoError(t, err)
 
+	// receiving from the process channel synchronizes with startOnce having
+	// set job.cmd, so the job can safely be signaled afterwards
+	p := make(chan *os.Process, 1)
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- job.startOnce(context.Background(), nil)
+		errChan <- job.startOnce(context.Background(), p)
 	}()
 
-	require.Eventually(t, func() bool {
-		return job.cmd != nil && job.cmd.Process != nil && syscall.Kill(job.cmd.Process.Pid, 0) == nil
-	}, 5*time.Second, 20*time.Millisecond, "process should be running")
+	select {
+	case proc := <-p:
+		require.NotNil(t, proc, "process should be running")
+	case <-time.After(5 * time.Second):
+		t.Fatal("process did not start")
+	}
 
 	return job, errChan
 }
@@ -35,7 +42,7 @@ func startTestJob(t *testing.T) (*baseJob, chan error) {
 func TestStartOnceReportsExpectedStopAsIntentional(t *testing.T) {
 	job, errChan := startTestJob(t)
 
-	job.stopExpected = true
+	job.stopExpected.Store(true)
 	job.Signal(syscall.SIGTERM)
 
 	select {

--- a/pkg/proc/job_common.go
+++ b/pkg/proc/job_common.go
@@ -126,7 +126,10 @@ func (job *CommonJob) Watch() {
 		signal := false
 		paths, err := filepath.Glob(watch.Filename)
 		if err != nil {
-			log.Warnf("failed to watch %s: %s", watch.Filename, err.Error())
+			log.WithField("job.name", job.Config.Name).
+				WithField("watch.path", watch.Filename).
+				WithError(err).
+				Warn("failed to watch files")
 			continue
 		}
 
@@ -142,7 +145,9 @@ func (job *CommonJob) Watch() {
 				continue
 			}
 
-			log.Infof("file %s changed, signalling process %s", p, job.Config.Name)
+			log.WithField("job.name", job.Config.Name).
+				WithField("watch.path", p).
+				Info("watched file changed, signaling process")
 			job.watchingFiles[p] = mtime
 			signal = true
 		}
@@ -151,7 +156,9 @@ func (job *CommonJob) Watch() {
 		for p := range job.watchingFiles {
 			_, err := os.Stat(p)
 			if os.IsNotExist(err) {
-				log.Infof("file %s not found, signalling process %s", p, job.Config.Name)
+				log.WithField("job.name", job.Config.Name).
+					WithField("watch.path", p).
+					Info("watched file removed, signaling process")
 				delete(job.watchingFiles, p)
 				signal = true
 			}

--- a/pkg/proc/job_common.go
+++ b/pkg/proc/job_common.go
@@ -82,7 +82,7 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 		case ProcessWillBeRestartedError:
 			l.Info("restart process")
 			continue
-		case ProcessWillBeStoppedError:
+		case ProcessWillBeStoppedError, ProcessStoppedIntentionallyError:
 			l.Info("stop process")
 			job.phase.Set(JobPhaseReasonStopped)
 			return nil

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"context"
+	"errors"
 	"os"
 	"sync"
 	"syscall"
@@ -31,7 +32,13 @@ func (job *LazyJob) AssertStarted(ctx context.Context) error {
 	e := make(chan error)
 
 	go func() {
-		if err := job.startOnce(ctx, p); err != nil {
+		err := job.startOnce(ctx, p)
+		switch {
+		case err == nil:
+			l.Info("process terminated")
+		case errors.Is(err, ProcessStoppedIntentionallyError):
+			l.Info("process stopped after cool-down")
+		default:
 			l.WithError(err).Error("process terminated with error")
 
 			select {
@@ -39,8 +46,6 @@ func (job *LazyJob) AssertStarted(ctx context.Context) error {
 			default:
 			}
 		}
-
-		l.Info("process terminated")
 
 		job.lazyStartLock.Lock()
 		defer job.lazyStartLock.Unlock()
@@ -77,13 +82,16 @@ func (job *LazyJob) Run(ctx context.Context, errors chan<- error) error {
 		}()
 	}
 
-	job.startProcessReaper(ctx)
+	job.startCoolDownWatcher(ctx)
 
 	log.Infof("holding off starting job %s until first request", job.Config.Name)
 	return nil
 }
 
-func (job *LazyJob) startProcessReaper(ctx context.Context) {
+// startCoolDownWatcher stops the job's process once it has been idle for
+// longer than the configured cool-down timeout; the next connection spins it
+// up again. Not to be confused with the zombie reaper in reaper_linux.go.
+func (job *LazyJob) startCoolDownWatcher(ctx context.Context) {
 	ticker := time.NewTicker(1 * time.Minute)
 	go func() {
 		for {
@@ -95,8 +103,8 @@ func (job *LazyJob) startProcessReaper(ctx context.Context) {
 					continue
 				}
 
-				diff := time.Since(job.lastConnectionClosed)
-				if diff < job.coolDownTimeout {
+				idle := time.Since(job.lastConnectionClosed)
+				if idle < job.coolDownTimeout {
 					continue
 				}
 
@@ -106,6 +114,11 @@ func (job *LazyJob) startProcessReaper(ctx context.Context) {
 
 				job.lazyStartLock.Lock()
 
+				log.WithField("job.name", job.Config.Name).
+					WithField("idle.duration", idle.Round(time.Second).String()).
+					Info("stopping idle lazy job after cool-down timeout")
+
+				job.stopExpected = true
 				job.Signal(syscall.SIGTERM)
 
 				job.lazyStartLock.Unlock()

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -29,7 +30,9 @@ func (job *LazyJob) AssertStarted(ctx context.Context) error {
 	}
 
 	p := make(chan *os.Process)
-	e := make(chan error)
+	// buffered so a startOnce failure is never dropped, even when it happens
+	// before the select below starts receiving
+	e := make(chan error, 1)
 
 	go func() {
 		err := job.startOnce(ctx, p)
@@ -40,11 +43,7 @@ func (job *LazyJob) AssertStarted(ctx context.Context) error {
 			l.Info("process stopped after cool-down")
 		default:
 			l.WithError(err).Error("process terminated with error")
-
-			select {
-			case e <- err:
-			default:
-			}
+			e <- err
 		}
 
 		job.lazyStartLock.Lock()
@@ -92,14 +91,16 @@ func (job *LazyJob) Run(ctx context.Context, errors chan<- error) error {
 // longer than the configured cool-down timeout; the next connection spins it
 // up again. Not to be confused with the zombie reaper in reaper_linux.go.
 func (job *LazyJob) startCoolDownWatcher(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Minute)
 	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if job.activeConnections > 0 {
+				if atomic.LoadUint32(&job.activeConnections) > 0 {
 					continue
 				}
 
@@ -118,7 +119,7 @@ func (job *LazyJob) startCoolDownWatcher(ctx context.Context) {
 					WithField("idle.duration", idle.Round(time.Second).String()).
 					Info("stopping idle lazy job after cool-down timeout")
 
-				job.stopExpected = true
+				job.stopExpected.Store(true)
 				job.Signal(syscall.SIGTERM)
 
 				job.lazyStartLock.Unlock()

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -83,7 +83,7 @@ func (job *LazyJob) Run(ctx context.Context, errors chan<- error) error {
 
 	job.startCoolDownWatcher(ctx)
 
-	log.Infof("holding off starting job %s until first request", job.Config.Name)
+	log.WithField("job.name", job.Config.Name).Info("holding off starting job until first request")
 	return nil
 }
 

--- a/pkg/proc/job_listener.go
+++ b/pkg/proc/job_listener.go
@@ -26,15 +26,16 @@ type acceptResult struct {
 }
 
 func NewListener(j *LazyJob, c *config.Listener) (*Listener, error) {
-	log.WithField("address", c.Address).Info("starting TCP listener")
+	l := log.WithField("job.name", j.Config.Name)
+	l.WithField("address", c.Address).Info("starting TCP listener")
 
 	// deprecation check
 	if c.Protocol != "" {
 		if c.ForwardProtocol == "" {
-			log.Warnf("field protocol in job %s is deprecated in favor of forwardProtocol", j.Config.Name)
+			l.Warn("field protocol is deprecated in favor of forwardProtocol")
 			c.ForwardProtocol = c.Protocol
 		} else {
-			log.Warnf("field protocol in job %s is ignored because it is deprecated and forwardProtocol is already set", j.Config.Name)
+			l.Warn("field protocol is ignored because it is deprecated and forwardProtocol is already set")
 		}
 	}
 
@@ -102,7 +103,9 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 				// received sigterm before new connection could have been established,
 				// we are about to shut down, close socket and listener and return
 				if err := l.socket.Close(); err != nil {
-					log.WithField("reason", err.Error()).Warn("cannot reliably close socket")
+					log.WithField("job.name", l.job.Config.Name).
+						WithError(err).
+						Warn("cannot reliably close socket")
 				}
 				return
 			case ar := <-connChan:
@@ -113,7 +116,9 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 				conn = ar.conn
 			}
 
-			log.WithField("client.addr", conn.RemoteAddr()).Info("accepted connection")
+			log.WithField("job.name", l.job.Config.Name).
+				WithField("client.addr", conn.RemoteAddr()).
+				Info("accepted connection")
 
 			if err := l.job.AssertStarted(ctx); err != nil {
 				errChan <- err
@@ -132,7 +137,9 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 
 				upstream, err := l.provideUpstreamConnection()
 				if err != nil {
-					log.WithError(err).Error("error while dialling upstream")
+					log.WithField("job.name", l.job.Config.Name).
+						WithError(err).
+						Error("error while dialling upstream")
 					return
 				}
 				defer upstream.Close()

--- a/pkg/proc/runner.go
+++ b/pkg/proc/runner.go
@@ -76,7 +76,7 @@ func (r *Runner) Boot() error {
 		return r.ctx.Err()
 
 	case err := <-bootErrs:
-		log.Error("boot job error occurred: ", err)
+		log.WithError(err).Error("boot job failed")
 		return err
 	}
 }
@@ -109,7 +109,7 @@ func (r *Runner) Run() error {
 
 		// handle errors
 		case err := <-r.errChan:
-			log.Error(err)
+			log.WithError(err).Error("job failed")
 			return err
 		}
 	}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -79,7 +80,7 @@ type baseJob struct {
 	cmd          *exec.Cmd
 	restart      bool
 	stop         bool
-	stopExpected bool
+	stopExpected atomic.Bool
 	stdout       *os.File
 	stderr       *os.File
 	lastError    error

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -76,13 +76,14 @@ type baseJob struct {
 	stdErrWg  sync.WaitGroup
 	stdOutWg  sync.WaitGroup
 
-	cmd       *exec.Cmd
-	restart   bool
-	stop      bool
-	stdout    *os.File
-	stderr    *os.File
-	lastError error
-	phase     JobPhase
+	cmd          *exec.Cmd
+	restart      bool
+	stop         bool
+	stopExpected bool
+	stdout       *os.File
+	stderr       *os.File
+	lastError    error
+	phase        JobPhase
 }
 
 type BootJob struct {

--- a/pkg/proc/wait_status.go
+++ b/pkg/proc/wait_status.go
@@ -1,6 +1,8 @@
 package proc
 
 import (
+	"errors"
+	"os/exec"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
@@ -22,4 +24,15 @@ func decodeWaitStatus(s syscall.WaitStatus) log.Fields {
 	default:
 		return log.Fields{"exit.status": int(s)}
 	}
+}
+
+// terminatedBySignal reports whether err is an exec.ExitError caused by the
+// process dying from the given signal.
+func terminatedBySignal(err error, sig syscall.Signal) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && ws.Signaled() && ws.Signal() == sig
 }


### PR DESCRIPTION
Stacked on #107.

## Problem

Stopping an idle lazy job after its cool-down timeout produced two error-level lines for completely expected behavior:

```
level=error msg="job exited with error" error="signal: terminated" job.name=mw-agent
level=error msg="process terminated with error" error="signal: terminated" job.name=mw-agent
```

The responsible function was also called `startProcessReaper`, which is far too easy to confuse with the PID-1 zombie reaper — an unrelated subsystem.

## Fix

- The cool-down watcher marks the stop as expected (`stopExpected`) before signaling; `startOnce` translates the resulting SIGTERM death into `ProcessStoppedIntentionallyError`, and the lazy job logs a single info line.
- `startProcessReaper` → `startCoolDownWatcher`, with an explicit trigger log including the idle duration.

A cool-down cycle now looks like this (all info level):

```
msg="stopping idle lazy job after cool-down timeout" idle.duration=58s job.name=lazy-web
msg="sending signal to process" job.name=lazy-web signal=terminated
msg="process stopped as requested" job.name=lazy-web
msg="process stopped after cool-down" job.name=lazy-web
```

## Verification

Unit tests assert that an expected SIGTERM yields `ProcessStoppedIntentionallyError` while an unexpected one still surfaces as `signal: terminated`. E2E in an alpine container as PID 1: full spin-up → cool-down cycle with zero error-level lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)