### PR TITLE
Make job-related log lines attributable via structured fields

### DIFF
--- a/pkg/proc/api.go
+++ b/pkg/proc/api.go
@@ -33,7 +33,7 @@ func (api *Api) Start() error {
 		Handler: api.router,
 	}
 
-	log.Infof("remote api listens on %s", api.srv.Addr)
+	log.WithField("api.addr", api.srv.Addr).Info("remote api listening")
 	if err := api.listen(); err != nil && err != http.ErrServerClosed {
 		return err
 	}

--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -27,41 +27,31 @@ var (
 )
 
 func (job *baseJob) SignalAll(sig syscall.Signal) {
-	errFunc := func(err error) {
-		if err != nil {
-			log.Warnf("failed to send signal %d to job %s: %s", sig, job.Config.Name, err.Error())
-		}
-	}
+	l := log.WithField("job.name", job.Config.Name).WithField("signal", sig)
 
 	if job.cmd == nil || job.cmd.Process == nil {
-		errFunc(
-			fmt.Errorf("job is not running"),
-		)
+		l.Warn("failed to send signal to process group: job is not running")
 		return
 	}
 
-	log.WithField("job.name", job.Config.Name).Infof("sending signal %d to process group", sig)
-	errFunc(syscall.Kill(-job.cmd.Process.Pid, sig))
+	l.Info("sending signal to process group")
+	if err := syscall.Kill(-job.cmd.Process.Pid, sig); err != nil {
+		l.WithError(err).Warn("failed to send signal to process group")
+	}
 }
 
 func (job *baseJob) Signal(sig os.Signal) {
-	errFunc := func(err error) {
-		if err != nil {
-			log.Warnf("failed to send signal %d to job %s: %s", sig, job.Config.Name, err.Error())
-		}
-	}
+	l := log.WithField("job.name", job.Config.Name).WithField("signal", sig)
 
 	if job.cmd == nil || job.cmd.Process == nil {
-		errFunc(
-			fmt.Errorf("job is not running"),
-		)
+		l.Warn("failed to send signal to process: job is not running")
 		return
 	}
 
-	log.WithField("job.name", job.Config.Name).Infof("sending signal %d to process", sig)
-	errFunc(
-		job.cmd.Process.Signal(sig),
-	)
+	l.Info("sending signal to process")
+	if err := job.cmd.Process.Signal(sig); err != nil {
+		l.WithError(err).Warn("failed to send signal to process")
+	}
 }
 
 func (job *baseJob) Reset() {
@@ -133,8 +123,9 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 		}
 		defer stderrPipe.Close()
 
-		go job.logWithTimestamp(stdoutPipe, job.stdout)
-		go job.logWithTimestamp(stderrPipe, job.stderr)
+		layout := job.resolveTimestampLayout(l)
+		go job.logWithTimestamp(stdoutPipe, job.stdout, layout)
+		go job.logWithTimestamp(stderrPipe, job.stderr, layout)
 	} else {
 		cmd.Stdout = job.stdout
 		cmd.Stderr = job.stderr
@@ -206,13 +197,13 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 	case <-ctx.Done():
 		// ctx canceled, try to terminate job
 		_ = syscall.Kill(-job.cmd.Process.Pid, syscall.SIGTERM)
-		l.WithField("job.name", job.Config.Name).Info("sent SIGTERM to job's process group")
+		l.Info("sent SIGTERM to job's process group")
 
 		select {
 		case <-time.After(time.Second * ShutdownWaitingTimeSeconds):
 			// process seems to hang, kill process
 			_ = syscall.Kill(-job.cmd.Process.Pid, syscall.SIGKILL)
-			l.WithField("job.name", job.Config.Name).Error("forcefully killed job")
+			l.Error("forcefully killed job")
 			return nil
 
 		case err := <-errChan:
@@ -234,25 +225,29 @@ func (job *baseJob) closeStdFiles() {
 	}
 }
 
-func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer) {
-	l := log.WithField("job.name", job.Config.Name)
-
-	var layout string
-
-	// has custom timestamp layout?
+// resolveTimestampLayout determines the timestamp layout for the job's log
+// output and logs the choice once per process start.
+func (job *baseJob) resolveTimestampLayout(l *log.Entry) string {
 	if job.Config.CustomTimestampFormat != "" {
-		layout = job.Config.CustomTimestampFormat
-		l.Infof("using custom timestamp layout '%s'", layout)
-	} else {
-		existingLayout, exists := TimeLayouts[job.Config.TimestampFormat]
-		if !exists {
-			layout = time.RFC3339
-			l.Warningf("unknown timestamp layout '%s', defaulting to RFC3339", job.Config.TimestampFormat)
-		} else {
-			layout = existingLayout
-			l.Infof("logging with timestamp layout '%s'", job.Config.TimestampFormat)
-		}
+		l.WithField("timestamp.layout", job.Config.CustomTimestampFormat).
+			Info("logging with custom timestamp layout")
+		return job.Config.CustomTimestampFormat
 	}
+
+	layout, exists := TimeLayouts[job.Config.TimestampFormat]
+	if !exists {
+		l.WithField("timestamp.layout", job.Config.TimestampFormat).
+			Warn("unknown timestamp layout, defaulting to RFC3339")
+		return time.RFC3339
+	}
+
+	l.WithField("timestamp.layout", job.Config.TimestampFormat).
+		Info("logging with timestamp layout")
+	return layout
+}
+
+func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer, layout string) {
+	l := log.WithField("job.name", job.Config.Name)
 
 	scanner := bufio.NewScanner(r)
 	prefix := []byte{'['}
@@ -276,13 +271,13 @@ func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer) {
 		lineBuffer.Write(newline)
 
 		if _, err := w.Write(lineBuffer.Bytes()); err != nil {
-			l.Errorf("error writing log line for process: %v\n", err)
+			l.WithError(err).Error("error writing log line for process")
 			continue
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		l.Errorf("error reading from process: %v\n", err)
+		l.WithError(err).Error("error reading from process")
 	}
 }
 

--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -226,7 +226,8 @@ func (job *baseJob) closeStdFiles() {
 }
 
 // resolveTimestampLayout determines the timestamp layout for the job's log
-// output and logs the choice once per process start.
+// output and logs the choice once per process start. timestamp.layout always
+// carries the effective Go time layout; timestamp.format the configured key.
 func (job *baseJob) resolveTimestampLayout(l *log.Entry) string {
 	if job.Config.CustomTimestampFormat != "" {
 		l.WithField("timestamp.layout", job.Config.CustomTimestampFormat).
@@ -236,12 +237,14 @@ func (job *baseJob) resolveTimestampLayout(l *log.Entry) string {
 
 	layout, exists := TimeLayouts[job.Config.TimestampFormat]
 	if !exists {
-		l.WithField("timestamp.layout", job.Config.TimestampFormat).
-			Warn("unknown timestamp layout, defaulting to RFC3339")
+		l.WithField("timestamp.format", job.Config.TimestampFormat).
+			WithField("timestamp.layout", time.RFC3339).
+			Warn("unknown timestamp format, defaulting to RFC3339")
 		return time.RFC3339
 	}
 
-	l.WithField("timestamp.layout", job.Config.TimestampFormat).
+	l.WithField("timestamp.format", job.Config.TimestampFormat).
+		WithField("timestamp.layout", layout).
 		Info("logging with timestamp layout")
 	return layout
 }

--- a/pkg/proc/job_common.go
+++ b/pkg/proc/job_common.go
@@ -126,7 +126,10 @@ func (job *CommonJob) Watch() {
 		signal := false
 		paths, err := filepath.Glob(watch.Filename)
 		if err != nil {
-			log.Warnf("failed to watch %s: %s", watch.Filename, err.Error())
+			log.WithField("job.name", job.Config.Name).
+				WithField("watch.path", watch.Filename).
+				WithError(err).
+				Warn("failed to watch files")
 			continue
 		}
 
@@ -142,7 +145,9 @@ func (job *CommonJob) Watch() {
 				continue
 			}
 
-			log.Infof("file %s changed, signalling process %s", p, job.Config.Name)
+			log.WithField("job.name", job.Config.Name).
+				WithField("watch.path", p).
+				Info("watched file changed, signaling process")
 			job.watchingFiles[p] = mtime
 			signal = true
 		}
@@ -151,7 +156,9 @@ func (job *CommonJob) Watch() {
 		for p := range job.watchingFiles {
 			_, err := os.Stat(p)
 			if os.IsNotExist(err) {
-				log.Infof("file %s not found, signalling process %s", p, job.Config.Name)
+				log.WithField("job.name", job.Config.Name).
+					WithField("watch.path", p).
+					Info("watched file removed, signaling process")
 				delete(job.watchingFiles, p)
 				signal = true
 			}

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -83,7 +83,7 @@ func (job *LazyJob) Run(ctx context.Context, errors chan<- error) error {
 
 	job.startCoolDownWatcher(ctx)
 
-	log.Infof("holding off starting job %s until first request", job.Config.Name)
+	log.WithField("job.name", job.Config.Name).Info("holding off starting job until first request")
 	return nil
 }
 

--- a/pkg/proc/job_listener.go
+++ b/pkg/proc/job_listener.go
@@ -26,15 +26,16 @@ type acceptResult struct {
 }
 
 func NewListener(j *LazyJob, c *config.Listener) (*Listener, error) {
-	log.WithField("address", c.Address).Info("starting TCP listener")
+	l := log.WithField("job.name", j.Config.Name)
+	l.WithField("address", c.Address).Info("starting TCP listener")
 
 	// deprecation check
 	if c.Protocol != "" {
 		if c.ForwardProtocol == "" {
-			log.Warnf("field protocol in job %s is deprecated in favor of forwardProtocol", j.Config.Name)
+			l.Warn("field protocol is deprecated in favor of forwardProtocol")
 			c.ForwardProtocol = c.Protocol
 		} else {
-			log.Warnf("field protocol in job %s is ignored because it is deprecated and forwardProtocol is already set", j.Config.Name)
+			l.Warn("field protocol is ignored because it is deprecated and forwardProtocol is already set")
 		}
 	}
 
@@ -102,7 +103,9 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 				// received sigterm before new connection could have been established,
 				// we are about to shut down, close socket and listener and return
 				if err := l.socket.Close(); err != nil {
-					log.WithField("reason", err.Error()).Warn("cannot reliably close socket")
+					log.WithField("job.name", l.job.Config.Name).
+						WithError(err).
+						Warn("cannot reliably close socket")
 				}
 				return
 			case ar := <-connChan:
@@ -113,7 +116,9 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 				conn = ar.conn
 			}
 
-			log.WithField("client.addr", conn.RemoteAddr()).Info("accepted connection")
+			log.WithField("job.name", l.job.Config.Name).
+				WithField("client.addr", conn.RemoteAddr()).
+				Info("accepted connection")
 
 			if err := l.job.AssertStarted(ctx); err != nil {
 				errChan <- err
@@ -132,7 +137,9 @@ func (l *Listener) run(ctx context.Context) <-chan error {
 
 				upstream, err := l.provideUpstreamConnection()
 				if err != nil {
-					log.WithError(err).Error("error while dialling upstream")
+					log.WithField("job.name", l.job.Config.Name).
+						WithError(err).
+						Error("error while dialling upstream")
 					return
 				}
 				defer upstream.Close()

--- a/pkg/proc/runner.go
+++ b/pkg/proc/runner.go
@@ -76,7 +76,7 @@ func (r *Runner) Boot() error {
 		return r.ctx.Err()
 
 	case err := <-bootErrs:
-		log.Error("boot job error occurred: ", err)
+		log.WithError(err).Error("boot job failed")
 		return err
 	}
 }
@@ -109,7 +109,7 @@ func (r *Runner) Run() error {
 
 		// handle errors
 		case err := <-r.errChan:
-			log.Error(err)
+			log.WithError(err).Error("job failed")
 			return err
 		}
 	}


### PR DESCRIPTION
Stacked on #107 and the cool-down PR.

## Problem

Many log lines couldn't be filtered per job — most notably `accepted connection` on lazy listeners carried only `client.addr`, watch events and signal sends were unstructured `Infof`/`Warnf`, and the timestamp-layout line was logged twice per job (once per stdout/stderr pipe).

## Fix

- Every job-related line now carries a `job.name` field, with a consistent field vocabulary: `job.name`, `client.addr`, `signal`, `watch.path`, `timestamp.layout` (reap lines from #107 add `pid`, `exit.code`, `exit.signal`).
- The timestamp layout is resolved and logged once per process start instead of once per pipe.

No behavior changes — log statements only.

## Verification

`go build` / `go test` on darwin and linux; E2E container run eyeballed for the new line shapes, e.g. `msg="accepted connection" client.addr="127.0.0.1:34025" job.name=lazy-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)