### PR TITLE
fix data races on job phase and stop/restart flags

### DIFF
--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -55,19 +55,33 @@ func (job *baseJob) Signal(sig os.Signal) {
 }
 
 func (job *baseJob) Reset() {
+	job.phaseMu.Lock()
+	defer job.phaseMu.Unlock()
 	job.phase = JobPhase{}
 }
 
 func (job *baseJob) MarkForRestart() {
-	job.restart = true
+	job.restart.Store(true)
 }
 
 func (job *baseJob) IsControllable() bool {
 	return job.Config.Controllable
 }
 
-func (job *baseJob) GetPhase() *JobPhase {
-	return &job.phase
+// GetPhase returns a snapshot of the job's current phase.
+func (job *baseJob) GetPhase() JobPhase {
+	job.phaseMu.Lock()
+	defer job.phaseMu.Unlock()
+	return job.phase
+}
+
+func (job *baseJob) SetPhase(reason JobPhaseReason) {
+	job.phaseMu.Lock()
+	defer job.phaseMu.Unlock()
+	if job.phase.Reason == reason {
+		return
+	}
+	job.phase = JobPhase{Reason: reason, LastChange: time.Now()}
 }
 
 func (job *baseJob) GetName() string {
@@ -174,13 +188,13 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 			}
 		}
 
-		if job.restart {
+		if job.restart.Load() {
 			l.Info("job stopped for restart")
-			job.restart = false
+			job.restart.Store(false)
 			return ProcessWillBeRestartedError
 		}
 
-		if job.stop {
+		if job.stop.Load() {
 			l.Info("job stopped")
 			return ProcessWillBeStoppedError
 		}

--- a/pkg/proc/job_common.go
+++ b/pkg/proc/job_common.go
@@ -20,8 +20,8 @@ const (
 )
 
 func (job *CommonJob) Init() {
-	job.restart = false
-	job.stop = false
+	job.restart.Store(false)
+	job.stop.Store(false)
 
 	for w := range job.Config.Watches {
 		watch := &job.Config.Watches[w]
@@ -44,7 +44,7 @@ func (job *CommonJob) Init() {
 }
 
 func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
-	if job.stop {
+	if job.stop.Load() {
 		return nil
 	}
 
@@ -59,12 +59,12 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 
 	go func() {
 		for range p {
-			job.phase.Set(JobPhaseReasonStarted)
+			job.SetPhase(JobPhaseReasonStarted)
 		}
 	}()
 
 	for { // restart failed jobs as long mittnite is running
-		if job.stop {
+		if job.stop.Load() {
 			return nil
 		}
 
@@ -75,7 +75,7 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 		case nil:
 			if job.Config.OneTime {
 				l.Info("one-time job has ended successfully")
-				job.phase.Set(JobPhaseReasonCompleted)
+				job.SetPhase(JobPhaseReasonCompleted)
 				return nil
 			}
 			l.Warn("job exited without errors")
@@ -84,7 +84,7 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 			continue
 		case ProcessWillBeStoppedError, ProcessStoppedIntentionallyError:
 			l.Info("stop process")
-			job.phase.Set(JobPhaseReasonStopped)
+			job.SetPhase(JobPhaseReasonStopped)
 			return nil
 		}
 
@@ -98,7 +98,7 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 			currBackOff := backOff
 			backOff = calculateNextBackOff(currBackOff, maxBackOff)
 
-			job.phase.Set(JobPhaseReasonCrashLooping)
+			job.SetPhase(JobPhaseReasonCrashLooping)
 			l.
 				WithField("job.maxAttempts", maxAttempts).
 				WithField("job.usedAttempts", attempts).
@@ -109,7 +109,7 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 			continue
 		}
 
-		job.phase.Set(JobPhaseReasonFailed)
+		job.SetPhase(JobPhaseReasonFailed)
 
 		if job.Config.CanFail {
 			l.WithField("job.maxAttempts", maxAttempts).Warn("reached max retries")
@@ -203,13 +203,13 @@ func (job *CommonJob) IsRunning() bool {
 }
 
 func (job *CommonJob) Restart() {
-	job.restart = true
+	job.restart.Store(true)
 	job.SignalAll(syscall.SIGTERM)
 	job.interrupt()
 }
 
 func (job *CommonJob) Stop() {
-	job.stop = true
+	job.stop.Store(true)
 	job.SignalAll(syscall.SIGTERM)
 	job.interrupt()
 }
@@ -223,7 +223,7 @@ func (job *CommonJob) Status() *CommonJobStatus {
 	return &CommonJobStatus{
 		Pid:     pid,
 		Running: job.IsRunning(),
-		Phase:   job.phase,
+		Phase:   job.GetPhase(),
 		Config:  job.Config,
 	}
 }

--- a/pkg/proc/runner.go
+++ b/pkg/proc/runner.go
@@ -192,7 +192,7 @@ func (r *Runner) addJobIfNotExists(job Job) {
 }
 
 func (r *Runner) startJob(job Job, initialPhase JobPhaseReason) {
-	job.GetPhase().Set(initialPhase)
+	job.SetPhase(initialPhase)
 	phase := job.GetPhase()
 	if phase.Is(JobPhaseReasonStopped) || phase.Is(JobPhaseReasonFailed) || phase.Is(JobPhaseReasonCrashLooping) {
 		return

--- a/pkg/proc/runner_test.go
+++ b/pkg/proc/runner_test.go
@@ -78,7 +78,7 @@ func TestTickDoesNotRestartStoppedJob(t *testing.T) {
 	runner.waitGroup = &sync.WaitGroup{}
 
 	// Simulate a job that was explicitly stopped via `mittnitectl job stop`.
-	runner.jobs[0].GetPhase().Set(JobPhaseReasonStopped)
+	runner.jobs[0].SetPhase(JobPhaseReasonStopped)
 
 	runner.tick()
 
@@ -107,7 +107,7 @@ func TestTickDoesNotRestartCompletedOneTimeJob(t *testing.T) {
 	runner.errChan = make(chan error, 16)
 	runner.waitGroup = &sync.WaitGroup{}
 
-	runner.jobs[0].GetPhase().Set(JobPhaseReasonCompleted)
+	runner.jobs[0].SetPhase(JobPhaseReasonCompleted)
 
 	runner.tick()
 

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -78,13 +78,15 @@ type baseJob struct {
 	stdOutWg  sync.WaitGroup
 
 	cmd          *exec.Cmd
-	restart      bool
-	stop         bool
+	restart      atomic.Bool
+	stop         atomic.Bool
 	stopExpected atomic.Bool
 	stdout       *os.File
 	stderr       *os.File
 	lastError    error
-	phase        JobPhase
+
+	phaseMu sync.Mutex
+	phase   JobPhase
 }
 
 type BootJob struct {
@@ -127,7 +129,8 @@ type Job interface {
 	Watch()
 	Reset()
 
-	GetPhase() *JobPhase
+	GetPhase() JobPhase
+	SetPhase(JobPhaseReason)
 	GetName() string
 }
 
@@ -137,7 +140,7 @@ func (job *baseJob) init(jobConfig *config.BaseJobConfig) error {
 	job.Config = jobConfig
 	job.stdout = os.Stdout
 	job.stderr = os.Stderr
-	job.phase.Set(JobPhaseReasonAwaitingReadiness)
+	job.SetPhase(JobPhaseReasonAwaitingReadiness)
 	if len(jobConfig.Stdout) == 0 {
 		return nil
 	}

--- a/pkg/proc/types_status.go
+++ b/pkg/proc/types_status.go
@@ -15,26 +15,14 @@ const (
 	JobPhaseReasonCrashLooping       JobPhaseReason = "crashLooping"
 )
 
+// JobPhase is a plain value describing a job's current phase. Jobs hand out
+// snapshots of it (see baseJob.GetPhase); mutation happens exclusively through
+// baseJob.SetPhase, which synchronizes concurrent access.
 type JobPhase struct {
 	Reason     JobPhaseReason `json:"reason"`
 	LastChange time.Time      `json:"lastChange"`
 }
 
-func (p *JobPhase) Set(reason JobPhaseReason) {
-	if p == nil {
-		p = &JobPhase{}
-	}
-	if p.Reason == reason {
-		return
-	}
-
-	p.LastChange = time.Now()
-	p.Reason = reason
-}
-
-func (p *JobPhase) Is(reason JobPhaseReason) bool {
-	if p == nil {
-		return false
-	}
+func (p JobPhase) Is(reason JobPhaseReason) bool {
 	return p.Reason == reason
 }


### PR DESCRIPTION
Fixes #111.

`go test -race ./pkg/proc/` failed on master: `JobPhase.Set`/`Is` were called on a `*JobPhase` shared between job goroutines, `Runner.tick` and the API without synchronization, and the `baseJob.stop`/`restart` bools were written by `Stop()`/`Restart()`/`MarkForRestart()` from API/watch goroutines while `startOnce` read them.

- `JobPhase` is now a plain snapshot value (JSON shape unchanged, so the API and `mittnitectl` are unaffected); all reads and writes go through `baseJob.GetPhase`/`SetPhase`, which guard the stored phase with a mutex. The `Job` interface changes accordingly: `GetPhase()` returns a snapshot instead of a shared pointer, and `SetPhase(JobPhaseReason)` is added. Keeping the lock out of `JobPhase` itself avoids re-introducing the copied-lock vet findings fixed in #115.
- `stop`/`restart` are now `atomic.Bool`, matching the `stopExpected` flag introduced in #108.
- The dead nil-receiver check in the old `JobPhase.Set` (assigning to a local copy of the pointer) is gone with the move.

`go vet ./...` and `go test -race -count=5 ./...` pass; this unblocks running `-race` in CI (#110).

Stacked on #115 (`fix/go-vet-issues`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)