### PR TITLE
run graceful job shutdown before exiting on SIGTERM

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,22 @@ on:
   pull_request:
 
 jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test -race ./...
+
   build:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Run go vet
         run: go vet ./...

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -141,15 +142,25 @@ var up = &cobra.Command{
 		}()
 
 		if err := runner.Boot(); err != nil {
+			if errors.Is(err, context.Canceled) {
+				log.Info("shutdown requested during boot")
+				return nil
+			}
 			log.WithError(err).Fatal("runner error'ed during initialization")
 		} else {
 			log.Info("initialization complete")
 		}
 
-		if err := runner.Run(); err != nil {
-			log.WithError(err).Fatal("service runner stopped with error")
-		} else {
+		// a canceled context is the normal SIGTERM/SIGINT shutdown path; the
+		// runner has already waited for the jobs' SIGTERM → SIGKILL escalation
+		err := runner.Run()
+		switch {
+		case err == nil:
 			log.Print("service runner stopped without error")
+		case errors.Is(err, context.Canceled):
+			log.Info("service runner shut down gracefully")
+		default:
+			log.WithError(err).Fatal("service runner stopped with error")
 		}
 
 		return nil

--- a/pkg/proc/job_common.go
+++ b/pkg/proc/job_common.go
@@ -64,13 +64,19 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 	}()
 
 	for { // restart failed jobs as long mittnite is running
-		if job.stop.Load() {
+		if job.stop.Load() || ctx.Err() != nil {
 			return nil
 		}
 
 		job.ctx, job.interrupt = context.WithCancel(context.Background())
 		startedAt := time.Now()
 		err := job.startOnce(ctx, p)
+		if ctx.Err() != nil {
+			// mittnite is shutting down; startOnce has already terminated the
+			// process (SIGTERM, then SIGKILL after the shutdown timeout)
+			job.SetPhase(JobPhaseReasonStopped)
+			return nil
+		}
 		switch err {
 		case nil:
 			if job.Config.OneTime {
@@ -105,7 +111,7 @@ func (job *CommonJob) Run(ctx context.Context, _ chan<- error) error {
 				WithField("job.nextRestartIn", currBackOff.String()).
 				Info("remaining attempts")
 
-			job.crashLoopSleep(currBackOff)
+			job.crashLoopSleep(ctx, currBackOff)
 			continue
 		}
 
@@ -246,21 +252,10 @@ func (job *CommonJob) executeWatchCommand(watchCmd *config.WatchCommand) error {
 	return cmd.Run()
 }
 
-func (job *CommonJob) crashLoopSleep(duration time.Duration) {
-	timeout := make(chan bool)
-
-	go func() {
-		defer close(timeout)
-		<-time.After(duration)
-		timeout <- true
-	}()
-
-	for {
-		select {
-		case <-timeout:
-			return
-		case <-job.ctx.Done():
-			return
-		}
+func (job *CommonJob) crashLoopSleep(ctx context.Context, duration time.Duration) {
+	select {
+	case <-time.After(duration):
+	case <-job.ctx.Done():
+	case <-ctx.Done():
 	}
 }

--- a/pkg/proc/job_lazy.go
+++ b/pkg/proc/job_lazy.go
@@ -59,7 +59,7 @@ func (job *LazyJob) AssertStarted(ctx context.Context) error {
 	}
 }
 
-func (job *LazyJob) Run(ctx context.Context, errors chan<- error) error {
+func (job *LazyJob) Run(ctx context.Context, errChan chan<- error) error {
 	listenerWaitGroup := sync.WaitGroup{}
 	defer listenerWaitGroup.Wait()
 
@@ -72,9 +72,9 @@ func (job *LazyJob) Run(ctx context.Context, errors chan<- error) error {
 		listenerWaitGroup.Add(1)
 
 		go func() {
-			if err := listener.Run(ctx); err != nil {
+			if err := listener.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 				log.WithError(err).Error("listener stopped with error")
-				errors <- err
+				errChan <- err
 			}
 
 			listenerWaitGroup.Done()

--- a/pkg/proc/job_listener.go
+++ b/pkg/proc/job_listener.go
@@ -59,7 +59,7 @@ func (l *Listener) Run(ctx context.Context) error {
 	case err := <-runErrors:
 		return err
 	case <-ctx.Done():
-		return errors.New("context closed")
+		return ctx.Err()
 	}
 }
 

--- a/pkg/proc/runner.go
+++ b/pkg/proc/runner.go
@@ -72,8 +72,22 @@ func (r *Runner) Boot() error {
 		return nil
 
 	case <-r.ctx.Done():
-		log.Warn("context cancelled")
-		return r.ctx.Err()
+		log.Info("context cancelled, waiting for boot jobs to shut down")
+		done := waitGroupToChannel(&wg)
+		timeout := time.After((ShutdownWaitingTimeSeconds + 5) * time.Second)
+		for {
+			select {
+			case <-done:
+				return r.ctx.Err()
+
+			case err := <-bootErrs:
+				log.WithError(err).Warn("boot job failed during shutdown")
+
+			case <-timeout:
+				log.Warn("timed out waiting for boot jobs to shut down")
+				return r.ctx.Err()
+			}
+		}
 
 	case err := <-bootErrs:
 		log.WithError(err).Error("boot job failed")
@@ -84,20 +98,23 @@ func (r *Runner) Boot() error {
 func (r *Runner) Run() error {
 	r.errChan = make(chan error)
 	r.waitGroup = &sync.WaitGroup{}
-	if r.keepRunning {
-		r.waitGroup.Add(1)
-		defer r.waitGroup.Done()
-	}
 	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 
 	r.exec()
 
-	wgChan := waitGroupToChannel(r.waitGroup)
+	// with keepRunning, wgChan stays nil and never fires, so the runner only
+	// exits via context cancellation or a job error
+	var wgChan <-chan struct{}
+	if !r.keepRunning {
+		wgChan = waitGroupToChannel(r.waitGroup)
+	}
+
 	for {
 		select {
 		case <-r.ctx.Done():
-			log.Warn("context cancelled")
-			return r.ctx.Err()
+			log.Info("context cancelled, waiting for jobs to shut down")
+			return r.waitForJobsToShutDown()
 
 		// wait for them all to finish, or one to fail
 		case <-wgChan:
@@ -111,6 +128,29 @@ func (r *Runner) Run() error {
 		case err := <-r.errChan:
 			log.WithError(err).Error("job failed")
 			return err
+		}
+	}
+}
+
+// waitForJobsToShutDown lets the job goroutines finish their SIGTERM →
+// SIGKILL escalation (see startOnce) before the runner returns and mittnite
+// exits; errChan keeps being drained so no job goroutine blocks on a final
+// send. The timeout is a safety net in case a job goroutine hangs anyway.
+func (r *Runner) waitForJobsToShutDown() error {
+	done := waitGroupToChannel(r.waitGroup)
+	timeout := time.After((ShutdownWaitingTimeSeconds + 5) * time.Second)
+
+	for {
+		select {
+		case <-done:
+			return r.ctx.Err()
+
+		case err := <-r.errChan:
+			log.WithError(err).Warn("job failed during shutdown")
+
+		case <-timeout:
+			log.Warn("timed out waiting for jobs to shut down")
+			return r.ctx.Err()
 		}
 	}
 }

--- a/pkg/proc/runner_test.go
+++ b/pkg/proc/runner_test.go
@@ -113,3 +113,85 @@ func TestTickDoesNotRestartCompletedOneTimeJob(t *testing.T) {
 
 	assert.True(t, runner.jobs[0].GetPhase().Is(JobPhaseReasonCompleted), "completed one-time job must stay completed")
 }
+
+func TestRunWaitsForJobShutdownOnCancel(t *testing.T) {
+	jobConfig := config.JobConfig{
+		BaseJobConfig: config.BaseJobConfig{
+			Name:    "test-shutdown-job",
+			Command: "sleep",
+			Args:    []string{"30"},
+		},
+	}
+
+	ignitionConfig := &config.Ignition{
+		Jobs: []config.JobConfig{jobConfig},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runner := NewRunner(ctx, nil, false, ignitionConfig)
+	require.NoError(t, runner.Init())
+
+	runResult := make(chan error, 1)
+	go func() { runResult <- runner.Run() }()
+
+	require.Eventually(t, func() bool {
+		return runner.jobs[0].GetPhase().Is(JobPhaseReasonStarted)
+	}, 5*time.Second, 20*time.Millisecond, "job should start")
+
+	cancel()
+
+	select {
+	case err := <-runResult:
+		assert.ErrorIs(t, err, context.Canceled, "cancellation should surface as context.Canceled, not a job error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not return after context cancellation")
+	}
+
+	assert.True(t, runner.jobs[0].GetPhase().Is(JobPhaseReasonStopped),
+		"job goroutine should have terminated the process before the runner returned")
+}
+
+func TestRunKeepRunningOutlivesFinishedJobs(t *testing.T) {
+	jobConfig := config.JobConfig{
+		BaseJobConfig: config.BaseJobConfig{
+			Name:    "test-onetime-job",
+			Command: "true",
+		},
+		OneTime: true,
+	}
+
+	ignitionConfig := &config.Ignition{
+		Jobs: []config.JobConfig{jobConfig},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runner := NewRunner(ctx, nil, true, ignitionConfig)
+	require.NoError(t, runner.Init())
+
+	runResult := make(chan error, 1)
+	go func() { runResult <- runner.Run() }()
+
+	require.Eventually(t, func() bool {
+		return runner.jobs[0].GetPhase().Is(JobPhaseReasonCompleted)
+	}, 5*time.Second, 20*time.Millisecond, "one-time job should complete")
+
+	select {
+	case err := <-runResult:
+		t.Fatalf("runner returned despite keepRunning: %v", err)
+	case <-time.After(300 * time.Millisecond):
+		// still running, as it should be
+	}
+
+	cancel()
+
+	select {
+	case err := <-runResult:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not return after context cancellation")
+	}
+}


### PR DESCRIPTION
Fixes #113.

On SIGTERM, `Runner.Run` returned `ctx.Err()` straight from the `<-r.ctx.Done()` branch and `cmd/up.go` called `log.Fatal` — so mittnite (PID 1) exited within the same second and the graceful-shutdown path in `startOnce` (SIGTERM to the job's process group → wait 10s → SIGKILL) was unreachable; jobs were killed by container-namespace teardown instead.

- **`Runner.Run`** now waits for the job goroutines after cancellation (`waitForJobsToShutDown`), draining `errChan` so no job goroutine deadlocks on a final send, with a `ShutdownWaitingTimeSeconds+5` safety timeout. `Boot` gets the same drain treatment.
- **`CommonJob.Run`** exits its restart loop when the runner context is cancelled instead of entering backoff/restart with a dead context, and the crash-loop backoff now wakes on shutdown too.
- **`cmd/up.go`** treats `context.Canceled` as the normal shutdown path (`service runner shut down gracefully`) instead of a fatal error, for both `Boot()` and `Run()`.
- **keepRunning** is now modeled as a nil `wgChan` (a select case that never fires) instead of an extra WaitGroup count, so shutdown can wait on the job WaitGroup without deadlocking on the runner's own hold.
- **`Listener.Run`** returns `ctx.Err()` on cancellation instead of a synthetic `"context closed"` error, and `LazyJob.Run` no longer logs/forwards cancellation as a listener failure.

New regression tests: `TestRunWaitsForJobShutdownOnCancel` (runner returns `context.Canceled` only after the job goroutine stopped the process) and `TestRunKeepRunningOutlivesFinishedJobs` (guards the keepRunning restructure). Both race-clean.

Verified E2E in docker as PID 1 (the scenario from #113): a job with `trap '' TERM` now gets the full escalation — `sent SIGTERM to job's process group` → 10s → `forcefully killed job` → exit 0 in ~11s; a well-behaved job brings the container down in under a second.

Known gap (pre-existing): the lazily spawned process of a `LazyJob` is stopped via the same `startOnce` escalation, but its goroutine isn't tracked by the runner's WaitGroup, so mittnite may exit before a TERM-ignoring lazy process is force-killed.

Stacked on #116 (`fix/jobphase-data-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)