### PR TITLE
run go vet and go test -race in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,22 @@ on:
   pull_request:
 
 jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test -race ./...
+
   build:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Run go vet
         run: go vet ./...


### PR DESCRIPTION
Fixes #110.

The `Build & Test` workflow only ran a Trivy scan and a goreleaser snapshot build — `go test` was never executed, so the test suite (including the reaper integration tests from #107 and the regression tests from #105) only ran when someone remembered to run it locally.

This adds a `test` job (parallel to `build`) running `go vet ./...` and `go test -race ./...`. The linux-only reaper tests (`PR_SET_CHILD_SUBREAPER`) run fine on ubuntu runners.

Stacked on #117 (`fix/graceful-shutdown`) because vet-clean (#115) and race-clean (#116) are prerequisites for these gates to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)