### PR TITLE
fix spurious pipe-close error when forwarding job output

### DIFF
--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -110,22 +110,34 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 
 	// pipe command's stdout and stderr through timestamp function if timestamps are enabled
 	// otherwise just redirect stdout and err to job.stdout and job.stderr
+	//
+	// the pipes are created manually instead of via cmd.StdoutPipe, because
+	// cmd.Wait closes those as soon as the main process exits, racing the
+	// readers' final reads ("read |0: file already closed") and cutting off
+	// output of forked child processes that outlive the main process. The
+	// reader goroutines own the read ends and close them on EOF, which arrives
+	// once all child-side writers are gone.
+	var pipeWriteEnds []*os.File
 	if job.Config.EnableTimestamps {
-		stdoutPipe, err := cmd.StdoutPipe()
+		stdoutReader, stdoutWriter, err := os.Pipe()
 		if err != nil {
 			return fmt.Errorf("failed to create stdout pipe for process: %s", err.Error())
 		}
-		defer stdoutPipe.Close()
 
-		stderrPipe, err := cmd.StderrPipe()
+		stderrReader, stderrWriter, err := os.Pipe()
 		if err != nil {
+			stdoutReader.Close()
+			stdoutWriter.Close()
 			return fmt.Errorf("failed to create stderr pipe for process: %s", err.Error())
 		}
-		defer stderrPipe.Close()
+
+		cmd.Stdout = stdoutWriter
+		cmd.Stderr = stderrWriter
+		pipeWriteEnds = []*os.File{stdoutWriter, stderrWriter}
 
 		layout := job.resolveTimestampLayout(l)
-		go job.logWithTimestamp(stdoutPipe, job.stdout, layout)
-		go job.logWithTimestamp(stderrPipe, job.stderr, layout)
+		go job.logWithTimestamp(stdoutReader, job.stdout, layout)
+		go job.logWithTimestamp(stderrReader, job.stderr, layout)
 	} else {
 		cmd.Stdout = job.stdout
 		cmd.Stderr = job.stderr
@@ -141,8 +153,17 @@ func (job *baseJob) startOnce(ctx context.Context, process chan<- *os.Process) e
 
 	l.Info("starting job")
 
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start job %s: %s", job.Config.Name, err.Error())
+	startErr := cmd.Start()
+
+	// a started child holds duplicates of the pipe write ends; close ours so
+	// the readers see EOF once all child-side writers are gone (immediately,
+	// if the start failed)
+	for _, w := range pipeWriteEnds {
+		w.Close()
+	}
+
+	if startErr != nil {
+		return fmt.Errorf("failed to start job %s: %s", job.Config.Name, startErr.Error())
 	}
 
 	// Only set job.cmd if cmd.Start() was successful
@@ -249,7 +270,9 @@ func (job *baseJob) resolveTimestampLayout(l *log.Entry) string {
 	return layout
 }
 
-func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer, layout string) {
+func (job *baseJob) logWithTimestamp(r io.ReadCloser, w io.Writer, layout string) {
+	defer r.Close()
+
 	l := log.WithField("job.name", job.Config.Name)
 
 	scanner := bufio.NewScanner(r)
@@ -274,6 +297,12 @@ func (job *baseJob) logWithTimestamp(r io.Reader, w io.Writer, layout string) {
 		lineBuffer.Write(newline)
 
 		if _, err := w.Write(lineBuffer.Bytes()); err != nil {
+			if errors.Is(err, os.ErrClosed) {
+				// the file-backed log target is closed once the job stops;
+				// drop remaining output of children that outlived the job
+				l.Debug("log target closed, stopping log forwarding")
+				return
+			}
 			l.WithError(err).Error("error writing log line for process")
 			continue
 		}

--- a/pkg/proc/basejob.go
+++ b/pkg/proc/basejob.go
@@ -299,9 +299,11 @@ func (job *baseJob) logWithTimestamp(r io.ReadCloser, w io.Writer, layout string
 		if _, err := w.Write(lineBuffer.Bytes()); err != nil {
 			if errors.Is(err, os.ErrClosed) {
 				// the file-backed log target is closed once the job stops;
-				// drop remaining output of children that outlived the job
-				l.Debug("log target closed, stopping log forwarding")
-				return
+				// keep draining the pipe so children that outlived the job
+				// are not killed by SIGPIPE, but discard their output
+				l.Debug("log target closed, discarding further output")
+				w = io.Discard
+				continue
 			}
 			l.WithError(err).Error("error writing log line for process")
 			continue

--- a/pkg/proc/basejob_test.go
+++ b/pkg/proc/basejob_test.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,11 +52,12 @@ func TestStartOnceKeepsLoggingOutputOfLingeringChildren(t *testing.T) {
 	defer logHook.Reset()
 
 	job, err := newBaseJob(&config.BaseJobConfig{
-		Name:             "lingering-job",
+		Name: "lingering-job",
 		// the child traps TERM because startOnce signals the job's process
-		// group once the main process has exited
+		// group once the main process has exited; the main process sleeps
+		// briefly so the trap is installed before the signal arrives
 		Command:          "sh",
-		Args:             []string{"-c", "(trap '' TERM; sleep 0.3; echo lingering) & echo main"},
+		Args:             []string{"-c", "(trap '' TERM; sleep 0.3; echo lingering) & echo main; sleep 0.2"},
 		EnableTimestamps: true,
 	})
 	require.NoError(t, err)
@@ -83,6 +85,38 @@ func TestStartOnceKeepsLoggingOutputOfLingeringChildren(t *testing.T) {
 	for _, entry := range logHook.AllEntries() {
 		require.NotEqual(t, "error reading from process", entry.Message)
 	}
+}
+
+// When the job's log target is file-backed, closeStdFiles closes it as soon as
+// the job stops. A child that outlived the job and keeps writing must not be
+// killed by SIGPIPE: the reader keeps draining the pipe and discards the
+// output instead of closing its read end.
+func TestStartOnceDrainsPipeAfterLogTargetCloses(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+
+	job, err := newBaseJob(&config.BaseJobConfig{
+		Name:    "draining-job",
+		Command: "sh",
+		// the second write happens well after the reader saw the closed log
+		// target; if the read end were closed by then, the write would raise
+		// SIGPIPE and the marker file would never be created. The main process
+		// sleeps briefly so the child has installed its TERM trap before
+		// startOnce signals the process group.
+		Args: []string{"-c", fmt.Sprintf(
+			"(trap '' TERM; sleep 0.3; echo lingering; sleep 0.3; echo again; : > %q) & echo main; sleep 0.2", marker,
+		)},
+		EnableTimestamps: true,
+		Stdout:           filepath.Join(dir, "stdout.log"),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, job.startOnce(context.Background(), nil))
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "lingering child should survive writing after the log target closed")
 }
 
 func TestStartOnceReportsExpectedStopAsIntentional(t *testing.T) {

--- a/pkg/proc/basejob_test.go
+++ b/pkg/proc/basejob_test.go
@@ -52,7 +52,8 @@ func TestStartOnceKeepsLoggingOutputOfLingeringChildren(t *testing.T) {
 	logHook := logtest.NewGlobal()
 	defer logHook.Reset()
 
-	job, err := newBaseJob(&config.BaseJobConfig{
+	job := &baseJob{}
+	err := job.init(&config.BaseJobConfig{
 		Name: "lingering-job",
 		// the child traps TERM because startOnce signals the job's process
 		// group once the main process has exited; the main process sleeps
@@ -96,7 +97,8 @@ func TestStartOnceDrainsPipeAfterLogTargetCloses(t *testing.T) {
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "marker")
 
-	job, err := newBaseJob(&config.BaseJobConfig{
+	job := &baseJob{}
+	err := job.init(&config.BaseJobConfig{
 		Name:    "draining-job",
 		Command: "sh",
 		// the second write happens well after the reader saw the closed log

--- a/pkg/proc/basejob_test.go
+++ b/pkg/proc/basejob_test.go
@@ -3,11 +3,14 @@ package proc
 import (
 	"context"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/mittwald/mittnite/internal/config"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +40,49 @@ func startTestJob(t *testing.T) (*baseJob, chan error) {
 	}
 
 	return job, errChan
+}
+
+// A job's forked children inherit the stdout/stderr pipes. Output they write
+// after the main process exited must still be forwarded, and the readers must
+// not report an error just because the job exited (cmd.StdoutPipe would be
+// closed by cmd.Wait mid-read, producing "read |0: file already closed").
+func TestStartOnceKeepsLoggingOutputOfLingeringChildren(t *testing.T) {
+	logHook := logtest.NewGlobal()
+	defer logHook.Reset()
+
+	job, err := newBaseJob(&config.BaseJobConfig{
+		Name:             "lingering-job",
+		// the child traps TERM because startOnce signals the job's process
+		// group once the main process has exited
+		Command:          "sh",
+		Args:             []string{"-c", "(trap '' TERM; sleep 0.3; echo lingering) & echo main"},
+		EnableTimestamps: true,
+	})
+	require.NoError(t, err)
+
+	// stand-in for the passthrough case (job.stdout = os.Stdout), which
+	// closeStdFiles leaves open when startOnce returns
+	logFile := filepath.Join(t.TempDir(), "stdout.log")
+	out, err := os.Create(logFile)
+	require.NoError(t, err)
+	defer out.Close()
+	job.stdout = out
+	job.stderr = out
+
+	// returns as soon as the main sh process exits, well before the forked
+	// child writes its line
+	require.NoError(t, job.startOnce(context.Background(), nil))
+
+	require.Eventually(t, func() bool {
+		content, err := os.ReadFile(logFile)
+		return err == nil &&
+			strings.Contains(string(content), "main") &&
+			strings.Contains(string(content), "lingering")
+	}, 5*time.Second, 50*time.Millisecond, "output of the lingering child should still be forwarded")
+
+	for _, entry := range logHook.AllEntries() {
+		require.NotEqual(t, "error reading from process", entry.Message)
+	}
 }
 
 func TestStartOnceReportsExpectedStopAsIntentional(t *testing.T) {


### PR DESCRIPTION
## Problem

Every exit of a job with `enableTimestamps` could log

```
level=error msg="error reading from process" error="read |0: file already closed" job.name=sshd
```

right after the (perfectly normal) process termination — e.g. on every lazy-job cool-down stop.

`startOnce` used `cmd.StdoutPipe()`/`cmd.StderrPipe()` together with an immediate `cmd.Wait()` in a goroutine. The `os/exec` docs explicitly call this out as incorrect:

> Wait will close the pipe after seeing the command exit […] It is thus incorrect to call Wait before all reads from the pipe have completed.

So `Wait` closes the parent's read ends while the `logWithTimestamp` readers are still blocked in a read, which then fails with `os.ErrClosed`. With forked children still holding the inherited write end (sshd session processes), the reader is guaranteed to be mid-read when the main process exits, making the error deterministic — and any output those children produce afterwards was cut off.

## Fix

Create the pipes manually with `os.Pipe()` and give each end a single owner:

- the child gets the write ends (`cmd.Stdout`/`cmd.Stderr`); the parent closes its copies right after `cmd.Start()`
- the reader goroutines own the read ends and close them on EOF, which arrives once **all** child-side writers are gone

`cmd.Wait()` no longer touches the pipes, so the race disappears by construction. Output of children that outlive the main process now keeps being forwarded (timestamped) until they exit, instead of being dropped with an error. If the job's file-backed log target has already been closed by `closeStdFiles`, the reader stops silently (debug log) instead of erroring per line; passthrough stdout/stderr is unaffected.

## Verification

- New regression test `TestStartOnceKeepsLoggingOutputOfLingeringChildren` (passes with `-race`; fails on master: the lingering output is lost and the reader errors)
- Docker E2E as PID 1 (alpine, job forks a TERM-trapping child, main exits after 1s):

```
[2026-07-23T20:48:27Z] main-output
time="..." level=warning msg="job exited without errors" job.name=lingerer
[2026-07-23T20:48:30Z] lingering-child-output          <- previously lost + error line
time="..." level=info msg="reaped orphaned process" exit.code=0 pid=19
```

No `error reading from process` in any run.

Independent of the open PR stack (#115–#118); based directly on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)